### PR TITLE
GreenCloud consistency, spelling corrections and grammar

### DIFF
--- a/docs/api/account.md
+++ b/docs/api/account.md
@@ -38,7 +38,7 @@ Empty body
 	"name": "Richard",
 	"surname": "Hill",
 	"address": {
-		"company": "Green cloud",
+		"company": "GreenCloud",
 		"street": "123 Hill St.",
 		"district": "North district",
 		"city": "England",
@@ -243,7 +243,7 @@ This endpoint allows users sign up for one of the 3 bundles we offer:
 | ------------------ | ---------------------------- | ----------------------------------------------- |
 | `name`             | DEVELOPER      				| `required` `oneof=STARTER DEVELOPER ENTERPRISE` |
 | `paymentMethod`    | pm_1MrQQuEt48Mjl075t4BHF9pw	| `required` `startswith=pm_`                     |
-| `address.company`  | Green Cloud    				| `optional` `alphanumspace`                      |
+| `address.company`  | GreenCloud    				| `optional` `alphanumspace`                      |
 | `address.street`   | Main st.       				| `required` `alphanumspace`                      |
 | `address.city`     | England        				| `required` `alphaspace`                         |
 | `address.district` | South district 				| `optional` `alphaspace`                         |
@@ -257,7 +257,7 @@ This endpoint allows users sign up for one of the 3 bundles we offer:
 	"name": "DEVELOPER",
 	"paymentMethod": "pm_1MrQQuEt48Mjl075t4BHF9pw",
 	"address": {
-		"company": "Green Cloud",  // optional
+		"company": "GreenCloud",  // optional
 		"street": "My House 8295",
 		"city": "Parana",
 		"district": "Entre Rios",  // optional
@@ -370,7 +370,7 @@ With this endpoint, authenticated users can change their credit card on file. Th
 | Key                | Example       				| Requirements                       |
 | ------------------ | ---------------------------- | ---------------------------------- |
 | `paymentMethod`    | pm_1MrQQuEt48Mjl075t4BHF9pw  | `required`                         |
-| `address.company`  | Green Cloud    				| `optional` `alphanumspace`         |
+| `address.company`  | GreenCloud    				| `optional` `alphanumspace`         |
 | `address.street`   | Main st.       				| `required` `alphanumspace`         |
 | `address.city`     | England        				| `required` `alphaspace`            |
 | `address.district` | South district 				| `optional` `alphaspace`            |
@@ -401,7 +401,7 @@ With this endpoint, authenticated users can change their credit card on file. Th
 {
 	"paymentMethod": "pm_1MrQQuEt48Mjl075t4BHF9pw",
 	"address": {
-		"company": "Green Cloud",  // optional
+		"company": "GreenCloud",  // optional
 		"street": "My House 8295",
 		"city": "Parana",
 		"district": "Entre Rios",  // optional

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -4,14 +4,14 @@ sidebar_position: 1
 
 # 🔒️ Authentication
 
-Green Cloud has built in Authentication from the ground up. From the early days we realised that security is a big part of a cloud system. As such we use industry strength encryption and STRONGLY encourage our users to use 2FA which dramatically reduces the chances of an attack on an account.
+GreenCloud has built in Authentication from the ground up. From the early days we realised that security is a big part of a cloud system. As such we use industry strength encryption and STRONGLY encourage our users to use 2FA which dramatically reduces the chances of an attack on an account.
 
 The first thing you will need to do is to Register an account.
 
 ## Register
 
 :::info
-Use this end point to register an account with Green Cloud. The succesful response is an HTTP 201 response. An email will be sent to the email address used, enabling them to complete the registration of their account.
+Use this end point to register an account with GreenCloud. The succesful response is an HTTP 201 response. An email will be sent to the email address used, enabling them to complete the registration of their account.
 :::
 
 #### Endpoint
@@ -26,12 +26,12 @@ Use this end point to register an account with Green Cloud. The succesful respon
 
 #### Request Body
 
-| Key        | Example        | Requirements                              |
-| ---------- | -------------- | ----------------------------------------- |
-| `name`     | Richard        | `required` `min=8` `containsany=!@#$%&\*` |
-| `surname`  | Hill           | `required` `alpha` `max=20`               |
-| `email`    | <sampleEmail/> | `required`                                |
-| `password` | Hello123!      | `required` `min=8` `containsany=!@#$%&*`  |
+| Key        | Example        | Requirements                              							  |
+| ---------- | -------------- | --------------------------------------------------------------------- |
+| `name`     | Richard        | `required` `min=8` 						 						   	  |
+| `surname`  | Hill           | `required` `alpha` `max=20`          							      |
+| `email`    | <sampleEmail/> | `required`                              							  |
+| `password` | Hello123!      | `required` `min=8` `max=128` `containsany=0-9` `containsany=!@#$%&*`  |
 
 #### Example Request
 

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -14,7 +14,7 @@ Welcome to the documentation on the GreenCloud Dispatcher. The Dispatcher can be
 -   Developers can send many HTTP requests and await the responses.
 -   The Dispatcher acts as a broker - matching up the incoming requests with the most appropriate node to handle the work load.
 
-In time Green Cloud will have multiple dispatchers around the globe. Our vision is to host small centers that will be powered by onsite renewable energy. With our paradigm of farming out work load to members we anticipate that our energy requirements for Dispatcher will be dramatically less than the current modern data center.
+In time GreenCloud will have multiple dispatchers around the globe. Our vision is to host small centers that will be powered by onsite renewable energy. With our paradigm of farming out work load to members we anticipate that our energy requirements for Dispatcher will be dramatically less than the current modern data center.
 
 The Dispatcher consists of a suite of microservices all working together to perform the collective tasks that make up the Dispatcher. This includes but is not limited to -:
 
@@ -24,11 +24,11 @@ The Dispatcher consists of a suite of microservices all working together to perf
 -   Invoice - a Micro service for handling all Invoice details.
 -   Node - is responsible for all the interactions with the nodes.
 -   Function - looks after all the functions that are created/running.
--   Payment - we pay our members for being part of Green Cloud - this microservices handles this.
+-   Payment - we pay our members for being part of GreenCloud - this microservices handles this.
 -   Endpoint - TODO ⚠️
 -   Task - TODO ⚠️
 -   Tag - TODO ⚠️
--   Dispatcher - The service that allocates the workload across the Green Cloud network.
+-   Dispatcher - The service that allocates the workload across the GreenCloud network.
 
 In detail the dispatcher can be thought of as an intelligent queue. People offering their machines for use arrive and depart depedent on three conditions -:
 

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -18,7 +18,7 @@ The Create endpoint is used to create a new public endpoint for a given function
 :::
 
 :::tip
-GreenCloud understands that a publicly available URL will concern some of our users. To this end we have provided the ability to be able to delete publicly URL. This means that it is perfectly acceptable to create a URL, call it - get the results -and then delete it.
+GreenCloud understands that a publicly available URL will concern some of our users. To this end we have provided the ability to be able to delete the publicly available URL. This means that it is perfectly acceptable to create a URL, call it - get the results -and then delete it.
 :::
 
 #### Endpoint
@@ -137,7 +137,7 @@ Response could be any valid HTTP response returned by the underlying function.
 <TabItem value="Text">
 
 ```js title="Status: 200 OK"
-"Hello from Green Cloud!"
+"Hello from GreenCloud!"
 ```
 
 </TabItem>

--- a/docs/api/function.md
+++ b/docs/api/function.md
@@ -15,7 +15,7 @@ A Function consists of -:
 1. Name - a non unique character string used to represent the function.
 2. Language - the language that the function is written in.
 
-    At the time of writing Green Cloud supports -:
+    At the time of writing GreenCloud supports -:
 
     GoLang, Node JS, Python, C#, Ruby
 
@@ -24,7 +24,7 @@ A Function consists of -:
 ## Create
 
 :::info
-Use this endpoint to create a function to use in the Green Cloud system. The response from a succesful call is an HTTP 201 in which the body of the response contains the ID of the newly created function.
+Use this endpoint to create a function to use in the GreenCloud system. The response from a succesful call is an HTTP 201 in which the body of the response contains the ID of the newly created function.
 :::
 
 #### Endpoint
@@ -177,7 +177,7 @@ Empty body
 ## List
 
 :::info
-Use this endpoint to get a list of functions in your Green Cloud account.
+Use this endpoint to get a list of functions in your GreenCloud account.
 :::
 
 #### Endpoint
@@ -235,7 +235,7 @@ Empty body
 ## List By Tag
 
 :::info
-Use this endpoint to get a list of functions by tag. Note that you need to pass the tag you are interested in as a query parameter. We introduced Tags into Green Cloud as a means to be able to better manage your Green Cloud assets. Please see the Tag documentation for more details.
+Use this endpoint to get a list of functions by tag. Note that you need to pass the tag you are interested in as a query parameter. We introduced Tags into GreenCloud as a means to be able to better manage your GreenCloud assets. Please see the Tag documentation for more details.
 :::
 
 #### Endpoint
@@ -297,7 +297,7 @@ Empty body
 ## Delete
 
 :::info
-Use this endpoint to delete a function from the Green Cloud system.
+Use this endpoint to delete a function from the GreenCloud system.
 :::
 
 #### Endpoint
@@ -331,7 +331,7 @@ Empty body
 ## Get Capabilities
 
 :::info
-Use this endpoint to get capabilities of a function on the Green Cloud system.
+Use this endpoint to get capabilities of a function on the GreenCloud system.
 :::
 
 #### Endpoint
@@ -371,7 +371,7 @@ Empty body
 ## Set Capabilities
 
 :::info
-In Green Cloud because of the disparate nature of the machines that will be connecting to the Dispatcher we use something called Capabailities to be able to clearly utilise the best suited machine to the computational task that the function requires. This is the purpose of Capabilities. In setting the capabilities of a function you can restrict the machines that that function executes on. The purpose of this is to run on the most optimal machine for the function.
+In GreenCloud, because of the disparate nature of the machines that will be connecting to the Dispatcher, we use something called Capabailities to be able to clearly utilise the best suited machine to the computational task that the function requires. This is the purpose of Capabilities. In setting the capabilities of a function you can restrict the machines that that function executes on. The purpose of this is to run on the most optimal machine for the function.
 :::
 
 #### Endpoint

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -12,7 +12,7 @@ TODO: Waiting on node update
 
 We use this end point to create a node. We pass in the ID of the node on the URL and a description in the body.
 
-#### End Point: [https://api.greencloud.dev/v1/node/hash_of_the_node](https://api.greencloud.dev/v1/node/hash_of_the_node
+#### End Point: [https://api.greencloud.dev/v1/node/hash_of_the_node](https://api.greencloud.dev/v1/node/hash_of_the_node)
 
 ```js title="HTTP VERB"
 POST
@@ -73,7 +73,7 @@ HTTP 200
 
 Call this end point with the 'hash' of the node that you wish to remove. Call the list end point to find the list of nodes in the account, each node has an associated hash. If there is an associated node for the hash it is removed from the account and a 204 HTTP response is returned.
 
-#### End Point: [https://api.greencloud.dev/v1/node/hash_of_the_node](https://api.greencloud.dev/v1/node/hash_of_the_node
+#### End Point: [https://api.greencloud.dev/v1/node/hash_of_the_node](https://api.greencloud.dev/v1/node/hash_of_the_node)
 
 ```js title="HTTP VERB"
 DELETE

--- a/docs/api/tags.md
+++ b/docs/api/tags.md
@@ -8,8 +8,8 @@ We have introduced the idea of tags in GreenCloud. You may be familiar with this
 
 Example usages we see for this are -:
 
-1. You may have many functions in your Green Cloud account. Imagine searching 100 functions to find one it could be tedious. Searching using a tag that reduces that 100 functions to 3 for example?
-2. Green Cloud will in future consist of more services ( Storage and Database ) - as such we will allow tags on all resources. Being able to use the same tag name across different services will effectively organise your GreenCloud services.
+1. You may have many functions in your GreenCloud account. Imagine searching 100 functions to find one, it could be tedious. Searching using a tag could reduce the number to sift through considerably.
+2. GreenCloud will in future consist of more services ( Storage and Database ) - as such we will allow tags on all resources. Being able to use the same tag name across different services will effectively organise your GreenCloud services.
 
 ## Create Tag
 

--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -198,7 +198,7 @@ Response could be any valid HTTP response returned by the underlying function.
 <TabItem value="Text">
 
 ```js title="Status: 200 OK"
-"Hello from Green Cloud!"
+"Hello from GreenCloud!"
 ```
 
 </TabItem>

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -39,7 +39,7 @@ GLOBAL OPTIONS:
 
 ## `login`
 
-Use this command to allow you to interact with the Green Cloud API. You will need you API Key which is in the Green Cloud Account section to be able to login.
+Use this command to allow you to interact with the GreenCloud API. You will need you API Key which is in the GreenCloud Account section to be able to login.
 
 ```
 $ gccli login --help
@@ -232,7 +232,7 @@ $ gccli status
 
 ## `function`
 
-This command will simply return all the sub commands that are available in the Green Cloud CLI.
+This command will simply return all the sub commands that are available in the GreenCloud CLI.
 
 ```
 $ gccli function --help
@@ -312,7 +312,7 @@ $ gccli function init
 
 ### `function start`
 
-This subcommand will attempt to start your function locally on your machine. You must make sure that you have docker installed and running. If the function is already running, Green Cloud will stop the function, rebuild it and start it again.
+This subcommand will attempt to start your function locally on your machine. You must make sure that you have docker installed and running. If the function is already running, GreenCloud will stop the function, rebuild it and start it again.
 
 ```
 $ gccli function start --help
@@ -386,7 +386,7 @@ $ gccli function edit
 
 ### `function invoke`
 
-The invoke subcommand allows you to call your function ( once it has been deployed into Green Cloud - see the deploy subcommand for more information ) and pass Body and Query Parameters to your function.
+The invoke subcommand allows you to call your function ( once it has been deployed into GreenCloud - see the deploy subcommand for more information ) and pass Body and Query Parameters to your function.
 
 ```
 $ gccli function invoke --help
@@ -459,7 +459,7 @@ OPTIONS:
 
 ### `function deploy`
 
-When you are happy with your function and ready to register it into Green Cloud - you use this command to build the container again and then publish it into the GreenCloud registry.
+When you are happy with your function and ready to register it into GreenCloud - you use this command to build the container again and then publish it into the GreenCloud registry.
 
 ```
 $ gccli function deploy --help
@@ -529,7 +529,7 @@ $ gccli function public
 
 ### `function delete`
 
-This command will delete the function from the list of functions in your account. You will be prompted to ensure you are sure that this is what you want to do. Remember - this will NOT delete your source code but simply the Green Cloud configuration that enables you to run that function on the internet. You must be in same directory as the function you wish to delete AND the .gcfunction file must be present. It is also possible to delete the function with an ID and passing the -i parameter.
+This command will delete the function from the list of functions in your account. You will be prompted to ensure you are sure that this is what you want to do. Remember - this will NOT delete your source code but simply the GreenCloud configuration that enables you to run that function on the internet. You must be in same directory as the function you wish to delete AND the .gcfunction file must be present. It is also possible to delete the function with an ID and passing the -i parameter.
 
 ```
 $ gccli function delete --help
@@ -566,7 +566,7 @@ $ gccli function delete
 
 ### `function restore`
 
-This is a VERY powerful and useful command. You can restore you Green Cloud function onto any machine. The command has some extra sub parameters that you can pass to either create the directory, the template or just the .gcfunction file.
+This is a VERY powerful and useful command. You can restore your GreenCloud function onto any machine. The command has some extra sub parameters that you can pass to either create the directory, the template or just the .gcfunction file.
 
 ```
 $ gccli function restore --help
@@ -602,7 +602,7 @@ $ gccli function restore -i 6477283e599b4ee92e5171231
 
 ## `update`
 
-This is another very nice feature of GreenCloud. We work hard to maintain the integrity of the Green Cloud system. As such we will check the version of the CLI that is interacting with the API and will stop out of date CLI's from interacting with the API. Run this command and it will automagically download the latest version and have it ready for use once it has completed. Nice :).
+This is another very nice feature of GreenCloud. We work hard to maintain the integrity of the GreenCloud system. As such we will check the version of the CLI that is interacting with the API and will stop out of date CLI's from interacting with the API. Run this command and it will automatically download the latest version and have it ready for use once it has completed. Nice :).
 
 ```
 $ gccli update --help

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -240,28 +240,28 @@ $ gccli function --help
 
 ```
 NAME:
-  gccli function - manage functions
+  gccli function - manages functions
 
 USAGE:
   gccli function command [command options] [arguments...]
 
 COMMANDS:
   init     generates a new function with the data provided
-  info     show information of current function
-  lang     list all available languages for function
+  info     shows information of current function
+  lang     lists all available languages for function
   start    starts function image to test locally
-  logs     display logs of local function
-  stop     stop function container running
-  edit     change name/description of current function
-  invoke   invoke a remote function
+  logs     displays logs of local function
+  stop     stops function container running
+  edit     changes name/description of current function
+  invoke   invokes a remote function
   result   gets result of task
   deploy   builds and pushes multi-arch container images
-  public   create public endpoint to invoke directly
-  list     list all functions
-  delete   delete function
-  restore  restore function by ID
-  sync     sync function from server
-  tasks    list all tasks
+  public   creates public endpoint to invoke directly
+  list     lists all functions
+  delete   deletes function
+  restore  restores function by ID
+  sync     syncs function from server
+  tasks    lists all tasks
 
 OPTIONS:
   --help, -h  show help
@@ -269,7 +269,7 @@ OPTIONS:
 
 ### `function init`
 
-This sud command of the function command initiates the configuration process of creating a new function.
+This subcommand of the function command initiates the configuration process of creating a new function.
 
 ```
 $ gccli function init --help
@@ -426,7 +426,7 @@ $ gccli function invoke
 
 ### `function result`
 
-Use this function sub command to obtain the results from a particular call. Every call in GreenCloud is assigned an ID. See above the 'ID:' section in the invoke response. Use this ID to get the results from your function.
+Use this function subcommand to obtain the results from a particular call. Every call in GreenCloud is assigned an ID. See above the 'ID:' section in the invoke response. Use this ID to get the results from your function.
 
 ```
 $ gccli function result --help

--- a/docs/guide/account.md
+++ b/docs/guide/account.md
@@ -4,11 +4,11 @@ sidebar_position: 1
 
 # Account
 
-To use Green Cloud you must have successfully registered for an account. Upon activation, you will be given a free quota to get you started and may upgrade when you are ready.
+To use GreenCloud you must have successfully registered for an account. Upon activation, you will be given a free quota to get you started and may upgrade when you are ready.
 
 ## Sign Up
 
-To sign up for a Green Cloud account please visit - [Green Cloud - Sign Up](https://app.greencloudcomputing.io/signup)
+To sign up for a GreenCloud account please visit - [GreenCloud - Sign Up](https://app.greencloudcomputing.io/signup)
 
 You will need to enter your
 
@@ -21,25 +21,25 @@ You will need to enter your
 
 ## Sign In
 
-To sign in, to your Green Cloud account please visit [Green Cloud - Sign In](https://www.app.greencloudcomputing.io/signin) :
+To sign in, to your GreenCloud account please visit [GreenCloud - Sign In](https://www.app.greencloudcomputing.io/signin) :
 
 You will need to enter the following information
 
--   Green Cloud account name ( email address )
--   Green Cloud account password
+-   GreenCloud account name ( email address )
+-   GreenCloud account password
 
 ![login](./img/signin.png)
 
-Upon the correct entry of credentials you will be re-directed to the Green Cloud App dashboard to curate your account.
+Upon the correct entry of credentials you will be re-directed to the GreenCloud App dashboard to curate your account.
 
 ![dashboard](./img/dashboard.png)
 
 ## Reset Password
 
-If you have forgotten your password, don't worry! See the steps below to reset your Green Cloud account password!
+If you have forgotten your password, don't worry! See the steps below to reset your GreenCloud account password!
 
--   Navigate to the reset password link [Green Cloud - Password Reset](https://app.greencloudcomputing.io/forgotten)
--   Enter your email address associated with your Green Cloud account
--   If the email address matches a know Green Cloud account you will receive an email with a password reset link in it.
+-   Navigate to the reset password link [GreenCloud - Password Reset](https://app.greencloudcomputing.io/forgotten)
+-   Enter your email address associated with your GreenCloud account
+-   If the email address matches a know GreenCloud account you will receive an email with a password reset link in it.
 
 ![reset](./img/reset.png)

--- a/docs/guide/cli/_category_.json
+++ b/docs/guide/cli/_category_.json
@@ -3,6 +3,6 @@
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "The best tool to use when working with Green Cloud"
+    "description": "The best tool to use when working with GreenCloud"
   }
 }

--- a/docs/guide/cli/creating a Function.md
+++ b/docs/guide/cli/creating a Function.md
@@ -17,7 +17,7 @@ In the near future, users will be able to schedule a function.
 
 ### Functions in the Cloud
 
-Functions are registered in Green Cloud by default. For local functions, click [here](#local-functions).
+Functions are registered in GreenCloud by default. For local functions, click [here](#local-functions).
 
 Once you are logged in, you can create a function by following these steps:
 
@@ -79,7 +79,7 @@ gccli fx init -n myFunction -l go -d 'my description' --offline
 
 ### 🔖 Available languages:
 
-Green Cloud supports the following languages at the time of writing:
+GreenCloud supports the following languages at the time of writing:
 
 -   🔆 GOLANG → go (1.18)
 -   🔆 PYTHON → py (3.7)

--- a/docs/guide/cli/installing the CLI.md
+++ b/docs/guide/cli/installing the CLI.md
@@ -4,9 +4,9 @@ sidebar_position: 2
 
 # 🧑‍💻 Installing the CLI !
 
-You can download the CLI from this link → [Green Cloud CLI Tool](https://dl.greencloudcomputing.io/gccli)
+You can download the CLI from this link → [GreenCloud CLI Tool](https://dl.greencloudcomputing.io/gccli)
 
-On Linux and OSX machines you will need to convert the file into a executable. Use the CHMOD command to achieve this -:
+On Linux and OSX machines you will need to convert the file into a executable. Use the CHMOD command to achieve this :-
 
 ```
 chmod +x gccli-0.5.2-darwin-amd64
@@ -16,11 +16,11 @@ This tells the operation system that the file is an executable. On MAC machines,
 
 ![Unknown Developer](../../img/dev-verified.png)
 
-then open the System Settings window (top left Apple icon) and select Security Settings. ( Specific namings may vary due to OS updates / versions ). You should see a screen that is similar to this -:
+then open the System Settings window (top left Apple icon) and select Security Settings. ( Specific namings may vary due to OS updates / versions ). You should see a screen that is similar to this :-
 
 ![Unknown Developer](../../img/allowapp.png)
 
-Click the button "Allow Anyway". The computer will ask you to authenticate with your user name or password.You should then be able to allow the CLI tool to be enabled on your machine!
+Click the button "Allow Anyway". The computer will ask you to authenticate with your user name or password. You should then be able to allow the CLI tool to be enabled on your machine!
 
 <cliWindow>
 

--- a/docs/guide/cli/introduction.md
+++ b/docs/guide/cli/introduction.md
@@ -4,21 +4,21 @@ sidebar_position: 1
 
 # 🧩 Introduction
 
-Where to start! The CLI is one of the earliest tools that we created with Green Cloud and it really is where a lot of the 'power' lies with Green Cloud and a software developer.
+Where to start! The CLI is one of the earliest tools that we created with GreenCloud and it really is where a lot of the 'power' lies with GreenCloud and a software developer.
 
-There are some pre-requisites to getting going with the CLI tool -:
+There are some pre-requisites to getting going with the CLI tool :-
 
 -   You will need to install [Docker](https://www.docker.com/) for your device as we use it extensively.
 
--   You will also need a valid Green Cloud account (create one here) [Green Cloud - Sign Up](https://app.greencloudcomputing.io/signup)
+-   You will also need a valid GreenCloud account (create one here) [GreenCloud - Sign Up](https://app.greencloudcomputing.io/signup)
 
--   You can download the CLI from -: [Green Cloud CLI Tool](https://dl.greencloudcomputing.io/gccli) - Make sure you select the correct version to download for your computer.
+-   You can download the CLI from -: [GreenCloud CLI Tool](https://dl.greencloudcomputing.io/gccli) - Make sure you select the correct version to download for your computer.
 
 See the next section for details about installing the CLI. What follows are some basic rules for using the CLI Tool.
 
-The format of commands in the CLI are as follows -:
+The format of commands in the CLI are as follows :-
 
-1. Display general CLI information by typing -:
+1. Display general CLI information by typing
 
 ```
 ./gccli

--- a/docs/guide/cli/logging in and out.md
+++ b/docs/guide/cli/logging in and out.md
@@ -18,7 +18,7 @@ import CLIWindow from '@site/src/components/CLIWindow';
 
 You've downloaded the CLI tool and are ready to start. Before you can get going you need to sign into the account.
 
-If you have not created a Green Cloud account yet then you can do so [here](https://app.greencloudcomputing.io/signup)
+If you have not created a GreenCloud account yet then you can do so [here](https://app.greencloudcomputing.io/signup)
 
 If all is in place simply type `gccli login` :
 
@@ -37,7 +37,7 @@ $ █
 
 </CLIWindow>
 
-You are now good to go and get started with Green Cloud functions! 🎉️
+You are now good to go and get started with GreenCloud functions! 🎉️
 
 ### Logging out
 

--- a/docs/guide/cli/run a function in the cloud.md
+++ b/docs/guide/cli/run a function in the cloud.md
@@ -86,11 +86,11 @@ $ gccli fx invoke
 👷 Validating inputs...
 📄 Obtaining local information...
 ⌚ Timeout → 10
-📄 Payload → Hello from Green Cloud!
+📄 Payload → Hello from GreenCloud!
 🚀 Invoking function...
 📌 ID: 6408a30b1815ce1e1d87731a
 📻 Waiting for task to output...
-🧾 200 → Hello from Green Cloud!
+🧾 200 → Hello from GreenCloud!
 $ █
 ```
 
@@ -107,7 +107,7 @@ $ gccli fx result
 👷 Validating inputs...
 🔖 ID → 6408a30b1815ce1e1d87731a
 📻 Waiting for task to output...
-🧾 200 → Hello from Green Cloud!
+🧾 200 → Hello from GreenCloud!
 $ █
 ```
 

--- a/docs/guide/cli/running locally.md
+++ b/docs/guide/cli/running locally.md
@@ -11,7 +11,7 @@ sidebar_position: 7
 
 :::
 
-During the creation of Green Cloud we realised that the software developer would need a method by which they could test their software locally first before publishing it into the Green Cloud.
+During the creation of GreenCloud we realised that the software developer would need a method by which they could test their software locally first before publishing it into the GreenCloud.
 
 To do this we make use of Docker and a special command in the CLI.
 

--- a/docs/guide/dashboardcreatedFunctions.md
+++ b/docs/guide/dashboardcreatedFunctions.md
@@ -4,16 +4,16 @@ sidebar_position: 7
 
 # Dashboard Created Functions
 
-If you have used the web site to create a function and you want to now work on that function, its easy and this guide will show you how.
+If you have used the web site to create a function and you now want to work on that function, it's easy and this guide will show you how.
 
 
 :::tip requirements
-- Green Cloud CLI tool [installed](https://dl.greencloudcomputing.io/gccli)
-- Logged into your account [use your api key](https://app.greencloudcomputing.io/account) 
-- The [Function ID](https://app.greencloudcomputing.io/functions). You can copy the function ID to the clip board by clicking the clipboard icon next to the function ID.
+- GreenCloud CLI tool [installed](https://dl.greencloudcomputing.io/gccli)
+- Logged into your account: [Use your api key](https://app.greencloudcomputing.io/account) 
+- The [Function ID](https://app.greencloudcomputing.io/functions). You can copy the Function ID to the clip board by clicking the clipboard icon next to the Function ID.
 :::
 
-Make sure you have all the requirements above in place and have created your function using the dashboard. Next you simply need to run the following command 
+Make sure you have all the requirements above in place and have created your Function using the dashboard. Next you simply need to run the following command 
 
 ```
 gccli fx restore -i 'ID'`
@@ -34,4 +34,4 @@ $ gccli fx restore -i 643bcb966c251c33d4b20c28
 
 </cliWindow>
 
-Please note that once you have started working on your function, GreenCloud does not handle source control. We prefer to let those people who are focussed on your source control needs to, like GitHub, GitLab etc to handle your source control needs. 
+Please note that once you have started working on your Function, GreenCloud does not handle source control. We prefer to let those people who are focussed on your source control needs, like GitHub, GitLab etc, handle them.

--- a/docs/guide/debuggingFunction.md
+++ b/docs/guide/debuggingFunction.md
@@ -8,10 +8,10 @@ Often there are times where it is essential to see the step by step calls in a G
 
 This example uses GO as the base language - however the technique we use can be applied to any of the languages that we support in GreenCloud.
 
-1. Create a GreenCloud function `gccli fx init` and follow the instrucitons - or - use [GreenCloud Dashboard](https://app.greencloudcomputing.io)
+1. Create a GreenCloud Function `gccli fx init` and follow the instrucitons - or - use [GreenCloud Dashboard](https://app.greencloudcomputing.io)
 2. In your code editor add a folder and call it 'debug'
 3. In this folder we are going to create file with a main entry point. In GoLang we do this by creating a file called 'main.go'
-4. Open the file and copy and past the following code -:
+4. Open the file and copy and past the following code :-
 
 ```
 package main

--- a/docs/guide/errors.md
+++ b/docs/guide/errors.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # I get this error....
 
-Below you will find the most common mistakes with solutions!
+Below you will find the most common mistakes, with their solutions!
 
 ### NEEDS_LOGIN
 
@@ -24,7 +24,7 @@ $ gccli login
 
 </cliWindow>
 
-You can find your api key in the account section of the Green Cloud dashboard [here](https://app.greencloudcomputing.io)
+You can find your api key in the account section of the GreenCloud dashboard [here](https://app.greencloudcomputing.io)
 
 ***
 ### NO_RUNNER
@@ -49,23 +49,23 @@ $ gccli fx invoke
 
 </cliWindow>
 
-To fix this simply run the command `gccli fx deploy` and wait for the function to build and deploy into GreenCloud. 
+To fix this simply run the command `gccli fx deploy` and wait for the Function to build and deploy into GreenCloud. 
 
-Once it has completed you can now invoke your function in the cloud!
+Once it has completed you can now invoke your Function in the cloud!
 
 ***
 ### NO_QUOTA_AVAILABLE
 
-When you see this message it means that you have used up all of the calls you have purchased in your Green Cloud account. There are several options that you can follow at this point but all of them require you to purchase some more calls via the GreenCloud bundles options.
+When you see this message it means that you have used up all of the calls you have purchased in your GreenCloud account. There are several options that you can follow at this point but all of them require you to purchase some more calls via the GreenCloud bundles options.
 
 Consider the number of calls you are making and the best plan that suits your needs. See [here](https://www.greencloudcomouting.io#pricing) for more information on our pricing. 
 
-Also it is worth considering looking at the settings page in the Account section of the dashboard. We can handle automatic renew and email alerst when quota is running low.
+Also it is worth considering looking at the settings page in the Account section of the dashboard. We can handle automatic renew and email alerts when your quota is running low.
 
 ***
 ### NEEDS_UPGRADE
 
-We work hard to ensure Green Cloud is running on the latest versions of software. As such, we perform a lot of checks and you will see this message when there has been an update to the CLI tool.
+We work hard to ensure GreenCloud is running on the latest versions of software. As such, we perform a lot of checks and you will see this message when there has been an update to the CLI tool.
 
 <cliWindow>
 

--- a/docs/guide/how do I update the CLI to the latest version.md
+++ b/docs/guide/how do I update the CLI to the latest version.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# How do I update my Green Cloud CLI to the latest version?
+# How do I update my GreenCloud CLI to the latest version?
 
 On Linux and Mac OS based systems we have a really simple method to update the CLI to the latest, just run the command
 
@@ -25,4 +25,4 @@ $ █
 
 </cliWindow>
 
-This update method is not supported on Windows systems. You will need to visit the (download)[dl.greencloudcomputing.io] web site and select the latest version. We are in the process of changing this method to one where you can download the latest build directly from the account section of the dashboard web site!
+This update method is not supported on Windows systems. You will need to visit the [download](dl.greencloudcomputing.io) web site and select the latest version. We are in the process of changing this method to one where you can download the latest build directly from the account section of the dashboard web site.

--- a/docs/guide/passing_parameters.md
+++ b/docs/guide/passing_parameters.md
@@ -2,9 +2,9 @@
 sidebar_position: 8
 ---
 
-# How do I pass parameters to a Green Cloud function ?
+# How do I pass parameters to a GreenCloud function ?
 
-It's nice to have low carbon functions like those offered by Green Cloud however the real power of them comes from being able to pass information to them. In GreenCloud we have two methods for passing information into a function -:
+It's nice to have low carbon functions like those offered by GreenCloud however the real power of them comes from being able to pass information to them. In GreenCloud we have two methods for passing information into a function :-
 
 ### Query Parameters
 
@@ -18,7 +18,7 @@ An example is as follows -:
 
 Here we have an imaginary URL that is passing query parameters to the URL in the form of a name (parameter_name) and a value (parameter=value). 
 
-You can add more parmeters to the URL simply by using the '&' sign, here is an example -: 
+You can add more parmeters to the URL simply by using the '&' sign, here is an example :-
 
 ```
  https://www.imaginaryfunction.com?parameter_name=parameter_value&parameter_name2=parameter_value2
@@ -26,7 +26,7 @@ You can add more parmeters to the URL simply by using the '&' sign, here is an e
 
 To be able to call your function from a URL you will need to have created a public URL. 
 
-1. You can create this by making sure you have deployed your function into GreenCloud -:
+1. You can create this by making sure you have deployed your function into GreenCloud :-
 
 <cliWindow>
 
@@ -67,10 +67,10 @@ You will receive the parameters inside your function on the **QueryString** prop
 
 ### HTTP Body
 
-Similarly you can pass data into your function using the Body property of the Request type. Typically this is JSON data although it can be many things.
-It is up to the developer to extract the data from the Body into the format that you are expecting. Handling any error conditions that arise from improper data.
+Similarly you can pass data into your Function using the Body property of the Request type. Typically this is JSON data although it can be many things.
+It is up to the developer to extract the data from the Body into the format that you are expecting, handling any error conditions that arise from improper data.
 
-Below is the contents of the GO language Request struct type -:
+Below is the contents of the GO language Request struct type :-
 
 ```
 type Request struct {

--- a/docs/guide/what languages can I use with Green Cloud.md
+++ b/docs/guide/what languages can I use with Green Cloud.md
@@ -2,9 +2,9 @@
 sidebar_position: 4
 ---
 
-# What software languages does Green Cloud support?
+# What software languages does GreenCloud support?
 
-Green Cloud supports the following languages at the time of writing:
+GreenCloud supports the following languages at the time of writing:
 
 -   🔆 GOLANG → go (1.18)
 -   🔆 PYTHON → py (3.7)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,30 +5,30 @@ slug: /
 
 # 👋 Welcome!
 
-It is great to have you with us and we welcome you to the documentation pages for Green Cloud. On this web site you will find detailed information about Green Cloud software tools we have created. Please use this web site as a reference source of all things Green Cloud!
+It is great to have you with us and we welcome you to the documentation pages for GreenCloud. On this web site you will find detailed information about GreenCloud software tools we have created. Please use this web site as a reference source of all things GreenCloud!
 
-If something doesn't quite look right - OR - its missing - please email us here -: hello@greencloudcomputing.io
+If something doesn't quite look right - OR - it's missing - please email us here -: hello@greencloudcomputing.io
 
-Below is an overview of the main constituent parts to the Green Cloud eco system.
+Below is an overview of the main constituent parts to the GreenCloud eco system.
 
 ![Green Cloud Overview](./img/greencloud-overview.png)
 
-What we have created with Green Cloud has not been attempted before. As such we have been refining our approach with regards to how we will handle the workload that we will be presented with.
+What we have created with GreenCloud has not been attempted before. As such we have been refining our approach with regards to how we will handle the workload that we will be presented with.
 
-The above diagram represents the fifth iteration of Green Cloud!
+The above diagram represents the fifth iteration of GreenCloud!
 
 What started out as simply getting one computer talking to another across the internet has grown in to a fully fledged scalable system that is capable of performing huge amounts of code execution / tasks on almost any platform!
 
-We have split the documentation in to the main sections of the Green Cloud software suite.
+We have split the documentation in to the main sections of the GreenCloud software suite.
 
 #### API
 
--   This section documents all of the microservices that we use in Green Cloud and how to call them.
+-   This section documents all of the microservices that we use in GreenCloud and how to call them.
 
 #### CLI
 
--   Possibly the most powerful tool in Green Cloud - this section documents its functionality and the best steps in how to use it.
+-   Possibly the most powerful tool in GreenCloud - this section documents its functionality and the best steps in how to use it.
 
 #### Guide
 
--   In this section we go over some common issues and also techniques we have created when working with Green Cloud.
+-   In this section we go over some common issues and also techniques we have created when working with GreenCloud.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,7 +6,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula")
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-    title: "Green Cloud Computing",
+    title: "GreenCloud Computing",
     tagline: "pioneering the green computing revolution",
     url: "https://docs.greencloud.dev",
     baseUrl: "/",
@@ -62,9 +62,9 @@ const config = {
         /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
         ({
             navbar: {
-                title: "Green Cloud",
+                title: "GreenCloud",
                 logo: {
-                    alt: "Green Cloud Computing",
+                    alt: "GreenCloud Computing",
                     src: "img/GC-Logo.svg",
                 },
                 items: [

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -10,7 +10,7 @@ const FeatureList = [
     description: (
       <>
         <Translate>
-          Learn about the API that we have created at Green Cloud.
+          Learn about the API that we have created at GreenCloud.
         </Translate>
       </>
     ),
@@ -22,8 +22,8 @@ const FeatureList = [
       <>
         <Translate>
           We created a powerful command line tool that allows you to control all
-          of your Green Cloud assets. Its fully documentated on this site and
-          its the fastest way to get started with Green Cloud!
+          of your GreenCloud assets. Its fully documentated on this site and
+          its the fastest way to get started with GreenCloud!
         </Translate>
       </>
     ),
@@ -34,9 +34,9 @@ const FeatureList = [
     description: (
       <>
         <Translate>
-        Green Cloud is a new way to perform serverless compute with the least
+        GreenCloud is a new way to perform serverless compute with the least
         amount of Carbon. As such this section is full of useful topics that
-        will help you get the best out of your Green Cloud account!
+        will help you get the best out of your GreenCloud account!
         </Translate>
       </>
     ),


### PR DESCRIPTION
Update across docs site to ensure consistency of greencloud. Amend some spelling and grammar.

Looks like a lot in one commit but most is just changing Green cloud to GreenCloud so it is consistent across all the different pages of the site. Rest is minor spelling corrections and grammar.

Within docs/api/authentication.md I have updated the requirements section for the request body to state that the user will be required to use at least one digit (0-9) and removed `containsany=!@#$%&\*` from the 'name' field as this is not required.

I also made some adjustments to some of the links as () were missing or in the wrong places resulting in links not appearing correctly on the website.

A couple of things I have noticed. The logo for the docs site is different to the main site, there is a space in Green Cloud on the docs site but not the main site.

Also part of the website for the signup page is covered by the banner at the top on smaller screen sizes.