### PR TITLE
Removing some docusaurus references

### DIFF
--- a/docs/api/_category_.json
+++ b/docs/api/_category_.json
@@ -3,6 +3,6 @@
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "5 minutes to learn the most important Docusaurus concepts."
+    "description": "Here you will find a complete set of API documentation for the GreenCloud platform"
   }
 }


### PR DESCRIPTION
In this PR we resolve an issue where we have some docusaurus original reference text. 

We replace this with some more GreenCloud sounding wording.