### PR TITLE
add base URL to API section of Docs

### DIFF
--- a/docs/api/_category_.json
+++ b/docs/api/_category_.json
@@ -3,6 +3,6 @@
   "position": 4,
   "link": {
     "type": "generated-index",
-    "description": "Here you will find a complete set of API documentation for the GreenCloud platform"
+    "description": "Here you will find a complete set of API documentation for the GreenCloud platform. The base URL for the API is https://api.greencloud.dev/v1 . The base URL to access your created public endpoints is https://api.greencloud.dev/gc ."
   }
 }

--- a/docs/api/_category_.json
+++ b/docs/api/_category_.json
@@ -3,6 +3,6 @@
   "position": 4,
   "link": {
     "type": "generated-index",
-    "description": "Here you will find a complete set of API documentation for the GreenCloud platform. The base URL for the API is https://api.greencloud.dev/v1 . The base URL to access your created public endpoints is https://api.greencloud.dev/gc ."
+    "description": "Here you will find a complete set of API documentation for the GreenCloud platform."
   }
 }

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import OriginalDocPage from '@theme-original/DocPage';
+import { useLocation } from 'react-router-dom';
+
+export default function DocPage(props) {
+  const location = useLocation();
+  const isApiCategory = location.pathname === '/category/-api'; // Adjust the path as necessary
+
+  useEffect(() => {
+    if (isApiCategory) {
+      const articleElement = document.querySelector('article.margin-top--lg');
+      if (articleElement && !document.querySelector('.api-info')) {
+        const apiInfoDiv = document.createElement('div');
+        apiInfoDiv.className = 'api-info';
+        apiInfoDiv.innerHTML = `
+          <p>
+            The base URL for the API is <a href="https://api.greencloud.dev/v1">https://api.greencloud.dev/v1</a>.
+            </p>
+            <p>
+            The base URL to access your created public endpoints is <a href="https://api.greencloud.dev/gc">https://api.greencloud.dev/gc</a>.
+          </p>
+        `;
+        articleElement.parentNode.insertBefore(apiInfoDiv, articleElement);
+      }
+    }
+  }, [location.pathname]); // Re-run the effect when the pathname changes
+
+  return <OriginalDocPage {...props} />;
+}

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -14,10 +14,10 @@ export default function DocPage(props) {
         apiInfoDiv.className = 'api-info';
         apiInfoDiv.innerHTML = `
           <p>
-            The base URL for the API is <a href="https://api.greencloud.dev/v1">https://api.greencloud.dev/v1</a>.
+            The base URL for the API is <a href="https://api.greencloud.dev/v1">https://api.greencloud.dev/v1</a>
             </p>
             <p>
-            The base URL to access your created public endpoints is <a href="https://api.greencloud.dev/gc">https://api.greencloud.dev/gc</a>.
+            The base URL to access your created public endpoints is <a href="https://api.greencloud.dev/gc">https://api.greencloud.dev/gc</a>
           </p>
         `;
         articleElement.parentNode.insertBefore(apiInfoDiv, articleElement);

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -14,7 +14,7 @@ export default function DocPage(props) {
         apiInfoDiv.className = 'api-info';
         apiInfoDiv.innerHTML = `
           <p>
-            The base URL for the API is <a href="https://api.greencloud.dev/v1">https://api.greencloud.dev/v1</a>
+            The base URL for the API is <a href="https://api.greencloud.dev/v1/">https://api.greencloud.dev/v1/</a>
             </p>
             <p>
             The base URL to access your created public endpoints is <a href="https://api.greencloud.dev/gc">https://api.greencloud.dev/gc</a>

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -17,7 +17,7 @@ export default function DocPage(props) {
             The base URL for the API is <a href="https://api.greencloud.dev/v1/">https://api.greencloud.dev/v1/</a>
             </p>
             <p>
-            The base URL to access your created public endpoints is <a href="https://api.greencloud.dev/gc">https://api.greencloud.dev/gc</a>
+            The base URL to access your created public endpoints is <a href="https://api.greencloud.dev/gc/">https://api.greencloud.dev/gc/</a>
           </p>
         `;
         articleElement.parentNode.insertBefore(apiInfoDiv, articleElement);


### PR DESCRIPTION
![image](https://github.com/greencloudcomputing/docs/assets/109963510/6faf9ae5-db7f-4ce9-930e-03c7e4d6c13b)

Have added the base URL for API and base URL for public endpoints to Header in API section of docs